### PR TITLE
[RPS-380] CI migration: sanitise duplicate paths

### DIFF
--- a/src/main/java/uk/nhs/digital/ps/migrator/report/DatasetMigrationImpact.java
+++ b/src/main/java/uk/nhs/digital/ps/migrator/report/DatasetMigrationImpact.java
@@ -3,11 +3,11 @@ package uk.nhs.digital.ps.migrator.report;
 public enum DatasetMigrationImpact {
 
     FIELD_MIGRATED_AS_IS("Field migrated as is"),
-    FIELD_MIGRATED_MODIFIED("Modified value migrated"),
     FIELD_NOT_MIGRATED("Field not migrated"),
     FIELD_MIGRATED_PARTIALLY("Field migrated partially"),
+    VALUE_MIGRATED_MODIFIED("Modified value migrated"),
     DATASET_NOT_MIGRATED("Dataset not migrated"),
-    ONE_DUPLICATE_DATASET_MIGRATED("Only one of duplicates migrated");
+    ONE_DUPLICATE_DATASET_MIGRATED("Only one duplicate migrated");
 
     private final String description;
 

--- a/src/main/java/uk/nhs/digital/ps/migrator/report/IncidentType.java
+++ b/src/main/java/uk/nhs/digital/ps/migrator/report/IncidentType.java
@@ -22,7 +22,7 @@ public enum IncidentType {
             + "\nare needed."
     ),
     DATE_WITH_EXTRA_TEXT(
-        FIELD_MIGRATED_MODIFIED,
+            VALUE_MIGRATED_MODIFIED,
         "Date found with additional text",
         "Date field | Value found | Interpreted as",
         "Date in the exported data contained some extra text. The imported Dataset"
@@ -74,15 +74,28 @@ public enum IncidentType {
             + "\nA decision is needed on whether the summary can be migrated as is"
             + "\nor does it require some sanitizing."
     ),
+    KNOWN_DUPLICATE_DATASET_PATH(
+            VALUE_MIGRATED_MODIFIED,
+            "Known, non-unique Dataset path",
+            "Updated path",
+            "A known dataset had its node name updated so that its path could remain unique."
+                    + "\nThis is due to two datasets having been defined in the"
+                    + "\nsame location, having different P-codes but the same title. Normally,"
+                    + "\nthis would result in only one of the duplicates being imported, but,"
+                    + "\nin this case, all datasets need importing, and so their paths had to "
+                    + "\nbe made unique by being appended with unique suffixes."
+                    + "\n"
+                    + "\nThe dataset has been migrated with updated node name; nothing else to do."
+    ),
     DUPLICATE_DATASET_PATH(
-        ONE_DUPLICATE_DATASET_MIGRATED,
-        "Multiple datasets share the same path",
-        "Shared path",
-        "More than one dataset have been found to have the same CMS path."
-            + "\nThis is probably due to two Datasets having been defined in the"
-            + "\nsame location, having different P-codes but the same title"
-            + "\n"
-            + "\nOffending datasets need reviewing in the existing portal."
+            ONE_DUPLICATE_DATASET_MIGRATED,
+            "Multiple datasets share the same path",
+            "Shared path",
+            "More than one dataset have been found to have the same CMS path."
+                    + "\nThis is probably due to two Datasets having been defined in the"
+                    + "\nsame location, having different P-codes but the same title"
+                    + "\n"
+                    + "\nOffending datasets need reviewing in the existing portal."
     ),
     DUPLICATE_PCODE_IMPORTED( // found when scanning list of all the JSON files prepared for import
         FIELD_MIGRATED_AS_IS,


### PR DESCRIPTION
Node names of a few known datasets now get suffixes appended
to make their paths unique and thus ensure all are imported.