### PR TITLE
Nil 112 rework doc type

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,15 @@ Note that, while `nesstarAttachmentDownloadFolder` is optional, it's useful to p
 default one under `/tmp`, so that the downloaded files would be preserved between OS sessions, thus avoiding having to
 spend time re-downloading them repeatedly.
 
+In the case of National Indicator Library content:
+```bash
+java -jar publication-system-migrator.jar \
+--nationalIndicatorImportPath=/home/dev/migration/Indicators.xlsx,\
+--nationalIndicatorAttachmentPath=/home/dev/migration/PDFpacks,\
+--taxonomyDefinitionImportPath=/home/dev/migration/Taxonomy.xlsx,\
+--generateImportPackage"
+```
+
 Files included in the command line above are latest at the moment of writing; for their latest versions go to Confluence
 page titled [Structure Mapping].
 

--- a/src/main/java/uk/nhs/digital/ps/migrator/config/ExecutionConfigurator.java
+++ b/src/main/java/uk/nhs/digital/ps/migrator/config/ExecutionConfigurator.java
@@ -43,6 +43,7 @@ public class ExecutionConfigurator {
     private static final String MIGRATION_REPORT_FILENAME_DEFAULT = "Clinical Indicators Migration Report {TIMESTAMP}.xlsx";
 
     private static final String NATIONAL_INDICATORS_IMPORT_PATH = "nationalIndicatorImportPath";
+    private static final String NATIONAL_INDICATORS_ATTACHMENT_PATH = "nationalIndicatorAttachmentPath";
 
     private final ExecutionParameters executionParameters;
 
@@ -70,6 +71,8 @@ public class ExecutionConfigurator {
         executionParameters.setGenerateImportPackage(args.containsOption(GENERATE_IMPORT_PACKAGE_FLAG));
 
         executionParameters.setNationalIndicatorImportPath(getPathArg(args, NATIONAL_INDICATORS_IMPORT_PATH));
+
+        executionParameters.setNationalIndicatorAttachmentPath(getPathArg(args, NATIONAL_INDICATORS_ATTACHMENT_PATH));
 
         initNesstarUnzippedArchiveDir();
         initMigrationReportOutputPath(args);
@@ -100,6 +103,13 @@ public class ExecutionConfigurator {
         }
 
         executionParameters.setNesstarAttachmentDownloadDir(pathArg);
+
+        pathArg = getPathArg(args, NATIONAL_INDICATORS_ATTACHMENT_PATH);
+        if (pathArg == null) {
+            pathArg = Paths.get(MIGRATOR_TEMP_DIR_PATH.toString(), ATTACHMENT_DOWNLOAD_DIR_NAME_DEFAULT);
+        }
+        
+        executionParameters.setNationalIndicatorAttachmentPath(pathArg);
     }
 
     private void initTaxonomyDefinitionOutputPath(final ApplicationArguments args) {

--- a/src/main/java/uk/nhs/digital/ps/migrator/config/ExecutionParameters.java
+++ b/src/main/java/uk/nhs/digital/ps/migrator/config/ExecutionParameters.java
@@ -26,7 +26,8 @@ public class ExecutionParameters {
     private boolean generateImportPackage;
     private Path importPackageDir;
 
-    private Path nationalIndicatorImportPath;   
+    private Path nationalIndicatorImportPath;  
+    private Path nationalIndicatorAttachmentPath;  
 
     public Path getNesstarUnzippedExportDir() {
         return nesstarUnzippedExportDir;
@@ -132,6 +133,14 @@ public class ExecutionParameters {
         this.nationalIndicatorImportPath = nationalIndicatorImportPath;
     }
 
+    public Path getNationalIndicatorAttachmentPath() {
+        return nationalIndicatorAttachmentPath;
+    }
+
+    public void setNationalIndicatorAttachmentPath(Path nationalIndicatorAttachmentPath) {
+        this.nationalIndicatorAttachmentPath = nationalIndicatorAttachmentPath;
+    }
+
     public boolean isGenerateImportPackage() {
         return generateImportPackage;
     }
@@ -163,6 +172,7 @@ public class ExecutionParameters {
             describe("nesstarFieldMappingImportPath", nesstarFieldMappingImportPath),
             describe("migrationReportFilePath", migrationReportFilePath),
             describe("nationalIndicatorImportPath", nationalIndicatorImportPath),
+            describe("nationalIndicatorAttachmentPath", nationalIndicatorAttachmentPath),
             describe("importPackageDir", importPackageDir)
         );
     }

--- a/src/main/java/uk/nhs/digital/ps/migrator/misc/TextHelper.java
+++ b/src/main/java/uk/nhs/digital/ps/migrator/misc/TextHelper.java
@@ -68,8 +68,15 @@ public class TextHelper {
             .collect(Collectors.joining("-"));
     }
 
-    //handle newline and inline quotes
+    //handle special characters in Json (e.g. escape slashes)
     public static String escapeSpecialCharsForJson(final String input){
-        return input.trim().replace("\n", "\\n").replace("\r", "\\r").replace("\"", "\\\"");
+        return input.trim().replace("\"", "\\\"");
     }
+
+    /**
+     * Wrap in paragraph tags and replace system new lines with breaks.
+     */
+    public static String convertToHtmlParagraph(final String input){
+        return "<p>" + input.trim().replace(System.getProperty("line.separator"),"<br>") + "</p>";
+    }    
 }

--- a/src/main/java/uk/nhs/digital/ps/migrator/model/hippo/NationalIndicator.java
+++ b/src/main/java/uk/nhs/digital/ps/migrator/model/hippo/NationalIndicator.java
@@ -1,5 +1,10 @@
 package uk.nhs.digital.ps.migrator.model.hippo;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import uk.nhs.digital.ps.migrator.model.taxonomy.TaxonomyTerm;
+
 public class NationalIndicator extends NationalIndicatorHippoImportableItem {
 
     private final String iapCode;
@@ -8,12 +13,14 @@ public class NationalIndicator extends NationalIndicatorHippoImportableItem {
     private final String reportingPeriod;
     private final String reportingLevel;
     private final String basedOn;
-    private final String contactAuthor;
+    private final String contactAuthorName;
+    private final String contactAuthorEmail;    
     private final String rating;
     private final String assuranceDate;
     private final String reviewDate;
     private final String indicatorSet;
     private final String purpose;
+    private final String briefDescription;    
     private final String definition;
     private final String dataSource;
     private final String numerator;
@@ -23,6 +30,10 @@ public class NationalIndicator extends NationalIndicatorHippoImportableItem {
     private final String interpretationGuidelines;
     private final String caveats;
     private final String taxonomyKeys;
+    private final String geographicCoverage; 
+    private final List<Attachment> attachments;
+    private final String qualityStatementUrl; 
+    private final String technicalSpecificationUrl;    
 
     public NationalIndicator(final NilFolder parent,
                        final String displayName,
@@ -32,12 +43,14 @@ public class NationalIndicator extends NationalIndicatorHippoImportableItem {
                        final String reportingPeriod,
                        final String reportingLevel,
                        final String basedOn,
-                       final String contactAuthor,
+                       final String contactAuthorName,
+                       final String contactAuthorEmail,
                        final String rating,
                        final String assuranceDate,
                        final String reviewDate,
                        final String indicatorSet,
                        final String purpose,
+                       final String briefDescription,                       
                        final String definition,
                        final String dataSource,
                        final String numerator,
@@ -46,8 +59,11 @@ public class NationalIndicator extends NationalIndicatorHippoImportableItem {
                        final String methodology,
                        final String interpretationGuidelines,
                        final String caveats,
-                       final String taxonomyKeys
-                       ) {
+                       final String taxonomyKeys,
+                       final String geographicCoverage,
+                       final String qualityStatementUrl,
+                       final String technicalSpecificationUrl,
+                       final List<Attachment> attachments) {
         super(parent, displayName);
         this.iapCode = iapCode;
         this.title = title;
@@ -55,12 +71,14 @@ public class NationalIndicator extends NationalIndicatorHippoImportableItem {
         this.reportingPeriod = reportingPeriod;
         this.reportingLevel = reportingLevel;
         this.basedOn = basedOn;
-        this.contactAuthor = contactAuthor;
+        this.contactAuthorName = contactAuthorName;
+        this.contactAuthorEmail = contactAuthorEmail;
         this.rating = rating;
         this.assuranceDate = assuranceDate;
         this.reviewDate = reviewDate;
         this.indicatorSet = indicatorSet;
         this.purpose = purpose;
+        this.briefDescription = briefDescription;
         this.definition = definition;
         this.dataSource = dataSource;
         this.numerator = numerator;
@@ -69,7 +87,20 @@ public class NationalIndicator extends NationalIndicatorHippoImportableItem {
         this.methodology = methodology;
         this.interpretationGuidelines = interpretationGuidelines;
         this.caveats = caveats;
-        this.taxonomyKeys = taxonomyKeys;
+        this.geographicCoverage = geographicCoverage;
+        this.qualityStatementUrl = qualityStatementUrl;
+        this.technicalSpecificationUrl = technicalSpecificationUrl;
+
+        //split the string on any ',' that is followed by an even number of double quotes, i.e. handle quoted taxonomy terms
+        List<String> taxKeys = Arrays.asList(taxonomyKeys.split(",(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)"));
+
+        List<String> convertedKeys = taxKeys.stream() // Convert collection to Stream
+				.map(TaxonomyTerm::covertTermToKey) // Convert each term to the sanitised taxonomy key
+                .collect(Collectors.toList()); // Collect results to a new list
+                
+        this.taxonomyKeys = String.join("\", \"", convertedKeys);
+
+        this.attachments = attachments;
     }
 
     public String getIapCode() {
@@ -96,9 +127,13 @@ public class NationalIndicator extends NationalIndicatorHippoImportableItem {
 		return basedOn;
 	}
 
-	public String getContactAuthor() {
-		return contactAuthor;
-	}
+	public String getContactAuthorName() {
+		return contactAuthorName;
+    }
+    
+	public String getContactAuthorEmail() {
+		return contactAuthorEmail;
+	}    
 
 	public String getRating() {
 		return rating;
@@ -118,6 +153,10 @@ public class NationalIndicator extends NationalIndicatorHippoImportableItem {
 
 	public String getPurpose() {
 		return purpose;
+	}
+
+	public String getBriefDescription() {
+		return briefDescription;
 	}
 
 	public String getDefinition() {
@@ -154,5 +193,21 @@ public class NationalIndicator extends NationalIndicatorHippoImportableItem {
     
 	public String getTaxonomyKeys() {
 		return taxonomyKeys;
-	}    
+    }    
+    
+	public String getGeographicCoverage() {
+		return geographicCoverage;
+    }  
+    
+	public String getQualityStatementUrl() {
+		return qualityStatementUrl;
+    }  
+
+	public String getTechnicalSpecificationUrl() {
+		return technicalSpecificationUrl;
+    }  
+
+    public List<Attachment> getAttachments() {
+        return attachments;
+    }    
 }

--- a/src/main/java/uk/nhs/digital/ps/migrator/model/hippo/NationalIndicatorMigrator.java
+++ b/src/main/java/uk/nhs/digital/ps/migrator/model/hippo/NationalIndicatorMigrator.java
@@ -1,12 +1,18 @@
 package uk.nhs.digital.ps.migrator.model.hippo;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.poi.ss.usermodel.Row;
 import uk.nhs.digital.ps.migrator.config.ExecutionParameters;
+import static org.apache.commons.io.FilenameUtils.removeExtension;
 
 /**
  * This class is responsible for loading national indicators to import into hippo.
@@ -16,7 +22,7 @@ public class NationalIndicatorMigrator {
     private ExecutionParameters executionParameters;
     private XlsxReader xlsxReader;
 
-    private static final String INDICATORS_SHEET_NAME = "Indicators";
+    private static final String INDICATORS_SHEET_NAME = "Indicators-Source";
 
     private static final String IAPCODE_COLUMN = "IAPCode";
     private static final String TITLE_COLUMN = "Title";
@@ -24,12 +30,14 @@ public class NationalIndicatorMigrator {
     private static final String REPORTINGPERIOD_COLUMN = "Reporting Period";   
     private static final String REPORTINGLEVELS_COLUMN = "Reporting level(s)";  
     private static final String BASEDONDATAFROM_COLUMN = "Based on data from";  
-    private static final String CONTACTAUTHOR_COLUMN = "Contact Author"; 
+    private static final String CONTACTAUTHORNAME_COLUMN = "Contact Author Name"; 
+    private static final String CONTACTAUTHOREMAIL_COLUMN = "Contact Author Email";     
     private static final String RATING_COLUMN = "Rating";     
     private static final String ASSURANCEDATE_COLUMN = "Assurance date";   
     private static final String REVIEWDATE_COLUMN = "Review date";       
     private static final String INDICATORSET_COLUMN = "Indicator Set";  
     private static final String PURPOSE_COLUMN = "Purpose";
+    private static final String BRIEFDESCRIPTION_COLUMN = "Brief Description";
     private static final String DEFINITION_COLUMN = "Definition";
     private static final String DATASOURCE_COLUMN = "Data Source";  
     private static final String NUMERATOR_COLUMN = "Numerator";  
@@ -39,8 +47,9 @@ public class NationalIndicatorMigrator {
     private static final String INTERPRETATIONGUIDELINES_COLUMN = "Interpretation Guidelines";  
     private static final String CAVEATS_COLUMN = "Caveats";  
     private static final String TAXONOMY_COLUMN = "Taxonomy";  
-
- 
+    private static final String GEOGRAPHICCOVERAGE_COLUMN = "Geographical Coverage";     
+    private static final String TECHNICALSPECIFICATION_COLUMN = "Technical Specification";   
+    private static final String QUALITYSTATEMENT_COLUMN = "Quality Statement";    
 
     public NationalIndicatorMigrator(ExecutionParameters executionParameters, XlsxReader xlsReader) {
         this.executionParameters = executionParameters;
@@ -75,24 +84,52 @@ public class NationalIndicatorMigrator {
                 this.xlsxReader.getCellValue(REPORTINGPERIOD_COLUMN,row),
                 this.xlsxReader.getCellValue(REPORTINGLEVELS_COLUMN,row),
                 this.xlsxReader.getCellValue(BASEDONDATAFROM_COLUMN,row),
-                this.xlsxReader.getCellValue(CONTACTAUTHOR_COLUMN,row),
+                this.xlsxReader.getCellValue(CONTACTAUTHORNAME_COLUMN,row),
+                this.xlsxReader.getCellValue(CONTACTAUTHOREMAIL_COLUMN,row),                
                 this.xlsxReader.getCellValue(RATING_COLUMN,row),
                 this.xlsxReader.getDateValue(ASSURANCEDATE_COLUMN,row),
                 this.xlsxReader.getDateValue(REVIEWDATE_COLUMN,row),
                 this.xlsxReader.getCellValue(INDICATORSET_COLUMN,row),
-                this.xlsxReader.getCellValue(PURPOSE_COLUMN,row),
-                this.xlsxReader.getCellValue(DEFINITION_COLUMN,row),
-                this.xlsxReader.getCellValue(DATASOURCE_COLUMN,row),
-                this.xlsxReader.getCellValue(NUMERATOR_COLUMN,row),
-                this.xlsxReader.getCellValue(DENOMINATOR_COLUMN,row),
-                this.xlsxReader.getCellValue(CALCULATION_COLUMN,row),   
-                this.xlsxReader.getCellValue(METHODOLOGY_COLUMN,row),                                                    
-                this.xlsxReader.getCellValue(INTERPRETATIONGUIDELINES_COLUMN,row),
-                this.xlsxReader.getCellValue(CAVEATS_COLUMN,row),
-                this.xlsxReader.getCellValue(TAXONOMY_COLUMN,row)
+                this.xlsxReader.getCellValueAsHtmlParagraph(PURPOSE_COLUMN,row),
+                this.xlsxReader.getCellValue(BRIEFDESCRIPTION_COLUMN,row),
+                this.xlsxReader.getCellValueAsHtmlParagraph(DEFINITION_COLUMN,row),
+                this.xlsxReader.getCellValueAsHtmlParagraph(DATASOURCE_COLUMN,row),
+                this.xlsxReader.getCellValueAsHtmlParagraph(NUMERATOR_COLUMN,row),
+                this.xlsxReader.getCellValueAsHtmlParagraph(DENOMINATOR_COLUMN,row),
+                this.xlsxReader.getCellValueAsHtmlParagraph(CALCULATION_COLUMN,row),   
+                this.xlsxReader.getCellValueAsHtmlParagraph(METHODOLOGY_COLUMN,row),                                                    
+                this.xlsxReader.getCellValueAsHtmlParagraph(INTERPRETATIONGUIDELINES_COLUMN,row),
+                this.xlsxReader.getCellValueAsHtmlParagraph(CAVEATS_COLUMN,row),
+                this.xlsxReader.getCellValue(TAXONOMY_COLUMN,row),
+                this.xlsxReader.getCellValue(GEOGRAPHICCOVERAGE_COLUMN,row),
+                this.xlsxReader.getCellValue(QUALITYSTATEMENT_COLUMN,row),
+                this.xlsxReader.getCellValue(TECHNICALSPECIFICATION_COLUMN,row),
+                getAttachments(executionParameters,this.xlsxReader.getCellValue(IAPCODE_COLUMN,row))
                 ));
         }
 
         return indicators;
+    }
+
+    /*
+     * Load all attachments from the NIL attachment path within a folder named with the IAP code. Gracefully handles
+     * non-existing folders as this is a valid use-case.
+     */
+    private List<Attachment> getAttachments(ExecutionParameters executionParameters, String iapCode) {
+        List<Attachment> attachments = new ArrayList<Attachment>();
+        
+        try (Stream<Path> stream = Files.walk(Paths.get(executionParameters.getNationalIndicatorAttachmentPath() + "/" + iapCode))){
+			attachments = stream
+            .filter(Files::isRegularFile)
+            .map(Path::toFile)
+            .map(f -> new Attachment(
+                    executionParameters.getNationalIndicatorAttachmentPath(),
+                    removeExtension(f.getName()),
+                    "/" + iapCode + "/" + f.getName(),
+                    null)).collect(Collectors.toList());
+		} catch (IOException e) {
+			// we don't care if the path doesn't exist 
+        }
+        return attachments;
     }
 }

--- a/src/main/java/uk/nhs/digital/ps/migrator/model/hippo/XlsxReader.java
+++ b/src/main/java/uk/nhs/digital/ps/migrator/model/hippo/XlsxReader.java
@@ -15,7 +15,6 @@ import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.xssf.usermodel.XSSFSheet;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
-
 import uk.nhs.digital.ps.migrator.misc.TextHelper;
 
 /**
@@ -94,7 +93,7 @@ public class XlsxReader {
 
         return this.headerNameIndexPairs.get(cleanHeader(columnName));    
     }
-  
+    
     /**
      * Returns string cell value. Apache code will throw exception if the cell is not of type string.
      */        
@@ -109,6 +108,18 @@ public class XlsxReader {
 
 
         return TextHelper.escapeSpecialCharsForJson(rawValue);
+    }
+
+    /**
+     * Returns the cell value is a HTML-handled paragraph. This is for the scenario where Hippo is expecting 'rich text',
+     * and without doing this, will automatically apply additional HTML when editing.
+     */
+    public String getCellValueAsHtmlParagraph(String columnName, Row row){
+        String cellValue = getCellValue(columnName, row);
+        if (cellValue == null || cellValue.length() == 0)
+            return null;
+
+        return TextHelper.convertToHtmlParagraph(cellValue);
     }
 
     /**

--- a/src/main/java/uk/nhs/digital/ps/migrator/model/taxonomy/TaxonomyTerm.java
+++ b/src/main/java/uk/nhs/digital/ps/migrator/model/taxonomy/TaxonomyTerm.java
@@ -41,6 +41,7 @@ public class TaxonomyTerm extends HippoNode {
         // Need unique names for the nodes and the taxonomy keys so we just use the
         // term after formatting into a valid path name.
         String key = term.trim()
+            .replace("\\\"", "")
             .replaceAll("[^A-z]", "-")
             .toLowerCase();
 

--- a/src/main/java/uk/nhs/digital/ps/migrator/task/GenerateImportPackageTask.java
+++ b/src/main/java/uk/nhs/digital/ps/migrator/task/GenerateImportPackageTask.java
@@ -40,8 +40,7 @@ public class GenerateImportPackageTask implements MigrationTask {
         // - exim/          - EXIM JSON import files
         // - attachments/   - attachment files
 
-        final Path importPackageDir = executionParameters.getImportPackageDir();
-        recreate(importPackageDir);
+        final Path importPackageDir = executionParameters.getImportPackageDir();     
 
         final Path importPackageSrcDir = Paths.get(importPackageDir.toString(), "src");
         final Path eximDir = Paths.get(importPackageSrcDir.toString(), "exim");
@@ -56,6 +55,7 @@ public class GenerateImportPackageTask implements MigrationTask {
         log.info("Copying content into the archive source dir {}", importPackageSrcDir);
         copyContent(executionParameters.getHippoImportDir(), eximDir);
         copyContent(executionParameters.getNesstarAttachmentDownloadDir(), attachmentsDir);
+        copyContent(executionParameters.getNationalIndicatorAttachmentPath(), attachmentsDir);
         log.info("Done.");
 
         generateImportPackageZipFile("import-package.zip", importPackageDir, importPackageSrcDir);

--- a/src/main/resources/templates/nationalindicator.json.ftl
+++ b/src/main/resources/templates/nationalindicator.json.ftl
@@ -1,113 +1,16 @@
 <#-- @ftlvariable name="nationalindicator" type="uk.nhs.digital.ps.migrator.model.hippo.NationalIndicator" -->
 {
   "name" : "${nationalindicator.jcrNodeName}",
+<<<<<<< HEAD
   "primaryType" : "nationalindicatorlibrary:indicator",
+=======
+>>>>>>> [RPS-308] CI migration: better import mechanism
   "mixinTypes" : [ "mix:referenceable", "hippotaxonomy:classifiable" ],
   "properties" : [ {
     "name" : "hippotranslation:locale",
     "type" : "STRING",
     "multiple" : false,
     "values" : [ "en" ]
-  }, {
-    "name" : "nationalindicatorlibrary:iapCode",
-    "type" : "STRING",
-    "multiple" : false,
-    "values" : [ "${nationalindicator.iapCode}" ]
-  }, {
-    "name" : "nationalindicatorlibrary:title",
-    "type" : "STRING",
-    "multiple" : false,
-    "values" : [ "${nationalindicator.title}" ]
-  }, {
-    "name" : "nationalindicatorlibrary:publishedBy",
-    "type" : "STRING",
-    "multiple" : false,
-    "values" : [ "${(nationalindicator.publishedBy)!}" ]
-  }, {
-    "name" : "nationalindicatorlibrary:reportingPeriod",
-    "type" : "STRING",
-    "multiple" : false,
-    "values" : [ "${(nationalindicator.reportingPeriod)!}" ]
-  }, {
-    "name" : "nationalindicatorlibrary:reportingLevel",
-    "type" : "STRING",
-    "multiple" : false,
-    "values" : [ "${(nationalindicator.reportingLevel)!}" ]
-  }, {
-    "name" : "nationalindicatorlibrary:basedOn",
-    "type" : "STRING",
-    "multiple" : false,
-    "values" : [ "${(nationalindicator.basedOn)!}" ]
-  }, {
-    "name" : "nationalindicatorlibrary:contactAuthor",
-    "type" : "STRING",
-    "multiple" : false,
-    "values" : [ "${(nationalindicator.contactAuthor)!}" ]
-  }, {
-    "name" : "nationalindicatorlibrary:rating",
-    "type" : "STRING",
-    "multiple" : false,
-    "values" : [ "${(nationalindicator.rating)!}" ]
-  }, {
-    "name" : "nationalindicatorlibrary:assuranceDate",
-    "type" : "STRING",
-    "multiple" : false,
-    "values" : [ "${(nationalindicator.assuranceDate)!}" ]    
-  }, {
-    "name" : "nationalindicatorlibrary:reviewDate",
-    "type" : "STRING",
-    "multiple" : false,
-    "values" : [ "${(nationalindicator.reviewDate)!}" ]
-  }, {
-    "name" : "nationalindicatorlibrary:indicatorSet",
-    "type" : "STRING",
-    "multiple" : false,
-    "values" : [ "${(nationalindicator.indicatorSet)!}" ]
-  }, {
-    "name" : "nationalindicatorlibrary:purpose",
-    "type" : "STRING",
-    "multiple" : false,
-    "values" : [ "${(nationalindicator.purpose)!}" ]
-  }, {
-    "name" : "nationalindicatorlibrary:definition",
-    "type" : "STRING",
-    "multiple" : false,
-    "values" : [ "${(nationalindicator.definition)!}" ]
-  }, {
-    "name" : "nationalindicatorlibrary:dataSource",
-    "type" : "STRING",
-    "multiple" : false,
-    "values" : [ "${(nationalindicator.dataSource)!}" ]
-  }, {
-    "name" : "nationalindicatorlibrary:numerator",
-    "type" : "STRING",
-    "multiple" : false,
-    "values" : [ "${(nationalindicator.numerator)!}" ]
-  }, {
-    "name" : "nationalindicatorlibrary:denominator",
-    "type" : "STRING",
-    "multiple" : false,
-    "values" : [ "${(nationalindicator.denominator)!}" ]
-  }, {
-    "name" : "nationalindicatorlibrary:calculation",
-    "type" : "STRING",
-    "multiple" : false,
-    "values" : [ "${(nationalindicator.calculation)!}" ]
-  }, {
-    "name" : "nationalindicatorlibrary:methodology",
-    "type" : "STRING",
-    "multiple" : false,
-    "values" : [ "${(nationalindicator.methodology)!}" ]
-  }, {
-    "name" : "nationalindicatorlibrary:interpretationGuidelines",
-    "type" : "STRING",
-    "multiple" : false,
-    "values" : [ "${(nationalindicator.interpretationGuidelines)!}" ]
-  }, {
-    "name" : "nationalindicatorlibrary:caveats",
-    "type" : "STRING",
-    "multiple" : false,
-    "values" : [ "${(nationalindicator.caveats)!}" ]
   }, {
     "name" : "jcr:path",
     "type" : "STRING",
@@ -118,6 +21,113 @@
     "type" : "STRING",
     "multiple" : false,
     "values" : [ "${nationalindicator.localizedName}" ]
+  }, {
+    "name" : "nationalindicatorlibrary:details",
+    "primaryType" : "nationalindicatorlibrary:details",
+    "mixinTypes" : [ ],
+    "properties" : [ {
+      "name" : "nationalindicatorlibrary:caveats",
+      "type" : "STRING",
+      "multiple" : false,
+      "values" : [ "${(nationalindicator.caveats)!}" ]
+    }, {
+      "name" : "nationalindicatorlibrary:definition",
+      "type" : "STRING",
+      "multiple" : false,
+      "values" : [ "${(nationalindicator.definition)!}" ]
+    }, {
+    "name" : "nationalindicatorlibrary:interpretationGuidelines",
+    "type" : "STRING",
+    "multiple" : false,
+    "values" : [ "${(nationalindicator.interpretationGuidelines)!}" ]
+    }, {
+        "name" : "nationalindicatorlibrary:methodology",
+        "primaryType" : "nationalindicatorlibrary:methodology",
+        "mixinTypes" : [ ],
+        "properties" : [ {
+            "name" : "nationalindicatorlibrary:calculation",
+            "type" : "STRING",
+            "multiple" : false,
+            "values" : [ "${(nationalindicator.calculation)!}" ]
+          }, {
+            "name" : "nationalindicatorlibrary:dataSource",
+            "type" : "STRING",
+            "multiple" : false,
+            "values" : [ "${(nationalindicator.dataSource)!}" ]
+          }, {
+            "name" : "nationalindicatorlibrary:denominator",
+            "type" : "STRING",
+            "multiple" : false,
+            "values" : [ "${(nationalindicator.denominator)!}" ]
+          }, {
+            "name" : "nationalindicatorlibrary:numerator",
+            "type" : "STRING",
+            "multiple" : false,
+            "values" : [ "${(nationalindicator.numerator)!}" ]
+          }
+        ],
+        "nodes" : [ ]
+    }
+    ],
+    "nodes" : [ ]
+  },{
+    "name" : "nationalindicatorlibrary:purpose",
+    "type" : "STRING",
+    "multiple" : false,
+    "values" : [ "${(nationalindicator.purpose)!}" ]
+  },<#if nationalindicator.taxonomyKeys?has_content> {
+    "name" : "hippotaxonomy:keys",
+    "type" : "STRING",
+<<<<<<< HEAD
+    "multiple" : false,
+    "values" : [ "${(nationalindicator.calculation)!}" ]
+  }, {
+    "name" : "nationalindicatorlibrary:methodology",
+    "type" : "STRING",
+    "multiple" : false,
+    "values" : [ "${(nationalindicator.methodology)!}" ]
+  }, {
+    "name" : "nationalindicatorlibrary:interpretationGuidelines",
+=======
+    "multiple" : true,
+    "values" : [ "${nationalindicator.taxonomyKeys}" ]
+  } </#if>,  {
+    "name" : "nationalindicatorlibrary:iapCode",
+>>>>>>> [RPS-308] CI migration: better import mechanism
+    "type" : "STRING",
+    "multiple" : false,
+    "values" : [ "${nationalindicator.iapCode}" ]
+  }, {
+    "name" : "nationalindicatorlibrary:indicatorSet",
+    "type" : "STRING",
+    "multiple" : false,
+    "values" : [ "${(nationalindicator.indicatorSet)!}" ]
+  }, {
+    "name" : "nationalindicatorlibrary:rating",
+    "type" : "STRING",
+    "multiple" : false,
+    "values" : [ "${(nationalindicator.rating)!}" ]
+  }, {
+    "name" : "nationalindicatorlibrary:topbar",
+    "primaryType" : "nationalindicatorlibrary:topbar",
+    "mixinTypes" : [ ],
+    "properties" : [  {
+      "name" : "nationalindicatorlibrary:contactAuthor",
+      "primaryType" : "nationalindicatorlibrary:contactAuthor",
+      "mixinTypes" : [ ],
+      "properties" : [ {
+        "name" : "nationalindicatorlibrary:contactAuthorName",
+        "type" : "STRING",
+        "multiple" : false,
+        "values" : [ "${(nationalindicator.contactAuthorName)!}" ]
+      } ],
+      "nodes" : [ ]
+    }, {
+    "name" : "nationalindicatorlibrary:title",
+    "type" : "STRING",
+    "multiple" : false,
+<<<<<<< HEAD
+    "values" : [ "${nationalindicator.localizedName}" ]
   },<#if nationalindicator.taxonomyKeys?has_content> {
        "name" : "hippotaxonomy:keys",
        "type" : "STRING",
@@ -126,3 +136,45 @@
   }</#if> ],
   "nodes" : [ ]
 }
+=======
+    "values" : [ "${nationalindicator.title}" ]
+    },{
+      "name" : "nationalindicatorlibrary:publishedBy",
+      "type" : "STRING",
+      "multiple" : false,
+      "values" : [ "${(nationalindicator.publishedBy)!}" ]
+    }, {
+      "name" : "nationalindicatorlibrary:reportingPeriod",
+      "type" : "STRING",
+      "multiple" : false,
+      "values" : [ "${(nationalindicator.reportingPeriod)!}" ]
+    }, {
+      "name" : "nationalindicatorlibrary:reportingLevel",
+      "type" : "STRING",
+      "multiple" : false,
+      "values" : [ "${(nationalindicator.reportingLevel)!}" ]
+    }, {
+      "name" : "nationalindicatorlibrary:basedOn",
+      "type" : "STRING",
+      "multiple" : false,
+      "values" : [ "${(nationalindicator.basedOn)!}" ]
+    }, {
+      "name" : "nationalindicatorlibrary:assuranceDate",
+      "type" : "STRING",
+      "multiple" : false,
+      "values" : [ "${(nationalindicator.assuranceDate)!}" ]    
+    }, {
+      "name" : "nationalindicatorlibrary:reviewDate",
+      "type" : "STRING",
+      "multiple" : false,
+      "values" : [ "${(nationalindicator.reviewDate)!}" ]
+    },{
+      "name" : "nationalindicatorlibrary:assuredStatus",
+      "type" : "STRING",
+      "multiple" : false,
+      "values" : [ "true" ]
+    }]
+  }],
+    "nodes" : [ ]
+  }  
+>>>>>>> [RPS-308] CI migration: better import mechanism

--- a/src/main/resources/templates/nationalindicator.json.ftl
+++ b/src/main/resources/templates/nationalindicator.json.ftl
@@ -1,17 +1,9 @@
 <#-- @ftlvariable name="nationalindicator" type="uk.nhs.digital.ps.migrator.model.hippo.NationalIndicator" -->
 {
   "name" : "${nationalindicator.jcrNodeName}",
-<<<<<<< HEAD
   "primaryType" : "nationalindicatorlibrary:indicator",
-=======
->>>>>>> [RPS-308] CI migration: better import mechanism
   "mixinTypes" : [ "mix:referenceable", "hippotaxonomy:classifiable" ],
   "properties" : [ {
-    "name" : "hippotranslation:locale",
-    "type" : "STRING",
-    "multiple" : false,
-    "values" : [ "en" ]
-  }, {
     "name" : "jcr:path",
     "type" : "STRING",
     "multiple" : false,
@@ -22,159 +14,289 @@
     "multiple" : false,
     "values" : [ "${nationalindicator.localizedName}" ]
   }, {
+    "name" : "hippotranslation:locale",
+    "type" : "STRING",
+    "multiple" : false,
+    "values" : [ "en" ]
+  }, {
+    "name" : "common:FacetType",
+    "type" : "STRING",
+    "multiple" : false,
+    "values" : [ "indicator" ]
+  }, {
+    "name" : "hippo:availability",
+    "type" : "STRING",
+    "multiple" : true,
+    "values" : [ ]
+  }, {
+    "name" : "common:searchable",
+    "type" : "BOOLEAN",
+    "multiple" : false,
+    "values" : [ "true" ]
+  }, {
+      "name" : "nationalindicatorlibrary:title",
+      "type" : "STRING",
+      "multiple" : false,
+      "values" : [ "${nationalindicator.title}" ]
+  }, {
+      "name" : "nationalindicatorlibrary:publishedBy",
+      "type" : "STRING",
+      "multiple" : false,
+      "values" : [ "${(nationalindicator.publishedBy)!}" ]
+  }, {
+      "name" : "nationalindicatorlibrary:reportingLevel",
+      "type" : "STRING",
+      "multiple" : false,
+      "values" : [ "${(nationalindicator.reportingLevel)!}" ]
+  }, {
+      "name" : "nationalindicatorlibrary:assuredStatus",
+      "type" : "BOOLEAN",
+      "multiple" : false,
+      "values" : [ "true" ]
+  }, {
+      "name" : "nationalindicatorlibrary:assuranceDate",
+      "type" : "DATE",
+      "multiple" : false,
+      "values" : [ "${(nationalindicator.assuranceDate)!}" ]
+  }, {
+      "name" : "publicationsystem:GeographicCoverage",
+      "type" : "STRING",
+      "multiple" : false,
+      "values" : [ "${(nationalindicator.geographicCoverage)!}" ]
+  }<#if nationalindicator.taxonomyKeys?has_content> ,{
+      "name" : "hippotaxonomy:keys",
+      "type" : "STRING",
+      "multiple" : true,
+      "values" : [ "${nationalindicator.taxonomyKeys}" ]
+  } </#if>],
+  "nodes" : [ 
+    <#if nationalindicator.attachments?size != 0> <#list nationalindicator.attachments as attachment> {
+    "name":"nationalindicatorlibrary:attachments",
+    "primaryType" : "publicationsystem:attachment",
+    "mixinTypes":[],
+    "properties" : [ {
+        "name" : "publicationsystem:displayName",
+        "type" : "STRING",
+        "multiple" : false,
+        "values" : [ "${attachment.title}" ]
+      } ],
+    "nodes" : [ {
+      "name" : "publicationsystem:attachmentResource",
+      "primaryType":"publicationsystem:resource",
+      "mixinTypes":[],
+      "properties":[ {
+          "name":"hippo:filename",
+          "type":"STRING",
+          "multiple":false,
+          "values":[ "${attachment.fileName}" ]
+        }, {
+          "name":"jcr:data",
+          "type":"BINARY",
+          "multiple":false,
+          "values":[ "file://${attachment.filePathWithPlaceholder}" ]
+        }, {
+          "name":"jcr:mimeType",
+          "type":"STRING",
+          "multiple":false,
+          "values":[ "${attachment.mimeType}" ]
+        }, {
+          "name":"jcr:lastModified",
+          "type":"DATE",
+          "multiple":false,
+          "values":[ "0001-01-01T12:00:00.000Z" ]
+        } ],
+      "nodes":[]
+    }]
+  } <#sep>,</#sep>
+  </#list>  
+  ,</#if> {
     "name" : "nationalindicatorlibrary:details",
     "primaryType" : "nationalindicatorlibrary:details",
-    "mixinTypes" : [ ],
+    "mixinTypes" : [ "hippotaxonomy:classifiable" ],
     "properties" : [ {
-      "name" : "nationalindicatorlibrary:caveats",
+      "name" : "nationalindicatorlibrary:indicatorSet",
       "type" : "STRING",
       "multiple" : false,
-      "values" : [ "${(nationalindicator.caveats)!}" ]
+      "values" : [ "${(nationalindicator.indicatorSet)!}" ]
+    }, {
+      "name" : "nationalindicatorlibrary:briefDescription",
+      "type" : "STRING",
+      "multiple" : false,
+      "values" : [ "${(nationalindicator.briefDescription)!}" ]
+    }, {
+      "name" : "nationalindicatorlibrary:technicalSpecificationUrl",
+      "type" : "STRING",
+      "multiple" : false,
+      "values" : [ "${(nationalindicator.technicalSpecificationUrl)!}" ]
+    }, {
+      "name" : "nationalindicatorlibrary:qualityStatementUrl",
+      "type" : "STRING",
+      "multiple" : false,
+      "values" : [ "${(nationalindicator.qualityStatementUrl)!}" ]
+    }, {
+      "name" : "nationalindicatorlibrary:iapCode",
+      "type" : "STRING",
+      "multiple" : false,
+      "values" : [ "${nationalindicator.iapCode}" ]
+    }, {
+      "name" : "nationalindicatorlibrary:rating",
+      "type" : "STRING",
+      "multiple" : false,
+      "values" : [ "${(nationalindicator.rating)!}" ]
+    } ],
+    "nodes" : [ {
+      "name" : "nationalindicatorlibrary:caveats",
+      "primaryType" : "hippostd:html",
+      "mixinTypes" : [ ],
+      "properties" : [ {
+        "name" : "hippostd:content",
+        "type" : "STRING",
+        "multiple" : false,
+        "values" : [ "${(nationalindicator.caveats)!}" ]
+      } ],
+      "nodes" : [ ]
     }, {
       "name" : "nationalindicatorlibrary:definition",
-      "type" : "STRING",
-      "multiple" : false,
-      "values" : [ "${(nationalindicator.definition)!}" ]
+      "primaryType" : "hippostd:html",
+      "mixinTypes" : [ ],
+      "properties" : [ {
+        "name" : "hippostd:content",
+        "type" : "STRING",
+        "multiple" : false,
+        "values" : [ "${(nationalindicator.definition)!}" ]
+      } ],
+      "nodes" : [ ]
     }, {
-    "name" : "nationalindicatorlibrary:interpretationGuidelines",
-    "type" : "STRING",
-    "multiple" : false,
-    "values" : [ "${(nationalindicator.interpretationGuidelines)!}" ]
+      "name" : "nationalindicatorlibrary:interpretationGuidelines",
+      "primaryType" : "hippostd:html",
+      "mixinTypes" : [ ],
+      "properties" : [ {
+        "name" : "hippostd:content",
+        "type" : "STRING",
+        "multiple" : false,
+        "values" : [ "${(nationalindicator.interpretationGuidelines)!}" ]
+      } ],
+      "nodes" : [ ]
     }, {
-        "name" : "nationalindicatorlibrary:methodology",
-        "primaryType" : "nationalindicatorlibrary:methodology",
+      "name" : "nationalindicatorlibrary:methodology",
+      "primaryType" : "nationalindicatorlibrary:methodology",
+      "mixinTypes" : [ ],
+      "properties" : [ ],
+      "nodes" : [ {
+        "name" : "nationalindicatorlibrary:calculation",
+        "primaryType" : "hippostd:html",
         "mixinTypes" : [ ],
         "properties" : [ {
-            "name" : "nationalindicatorlibrary:calculation",
-            "type" : "STRING",
-            "multiple" : false,
-            "values" : [ "${(nationalindicator.calculation)!}" ]
-          }, {
-            "name" : "nationalindicatorlibrary:dataSource",
-            "type" : "STRING",
-            "multiple" : false,
-            "values" : [ "${(nationalindicator.dataSource)!}" ]
-          }, {
-            "name" : "nationalindicatorlibrary:denominator",
-            "type" : "STRING",
-            "multiple" : false,
-            "values" : [ "${(nationalindicator.denominator)!}" ]
-          }, {
-            "name" : "nationalindicatorlibrary:numerator",
-            "type" : "STRING",
-            "multiple" : false,
-            "values" : [ "${(nationalindicator.numerator)!}" ]
-          }
-        ],
+          "name" : "hippostd:content",
+          "type" : "STRING",
+          "multiple" : false,
+          "values" : [ "${(nationalindicator.calculation)!}" ]
+        } ],
         "nodes" : [ ]
-    }
-    ],
-    "nodes" : [ ]
-  },{
-    "name" : "nationalindicatorlibrary:purpose",
-    "type" : "STRING",
-    "multiple" : false,
-    "values" : [ "${(nationalindicator.purpose)!}" ]
-  },<#if nationalindicator.taxonomyKeys?has_content> {
-    "name" : "hippotaxonomy:keys",
-    "type" : "STRING",
-<<<<<<< HEAD
-    "multiple" : false,
-    "values" : [ "${(nationalindicator.calculation)!}" ]
-  }, {
-    "name" : "nationalindicatorlibrary:methodology",
-    "type" : "STRING",
-    "multiple" : false,
-    "values" : [ "${(nationalindicator.methodology)!}" ]
-  }, {
-    "name" : "nationalindicatorlibrary:interpretationGuidelines",
-=======
-    "multiple" : true,
-    "values" : [ "${nationalindicator.taxonomyKeys}" ]
-  } </#if>,  {
-    "name" : "nationalindicatorlibrary:iapCode",
->>>>>>> [RPS-308] CI migration: better import mechanism
-    "type" : "STRING",
-    "multiple" : false,
-    "values" : [ "${nationalindicator.iapCode}" ]
-  }, {
-    "name" : "nationalindicatorlibrary:indicatorSet",
-    "type" : "STRING",
-    "multiple" : false,
-    "values" : [ "${(nationalindicator.indicatorSet)!}" ]
-  }, {
-    "name" : "nationalindicatorlibrary:rating",
-    "type" : "STRING",
-    "multiple" : false,
-    "values" : [ "${(nationalindicator.rating)!}" ]
+      }, {
+        "name" : "nationalindicatorlibrary:caveats",
+        "primaryType" : "hippostd:html",
+        "mixinTypes" : [ ],
+        "properties" : [ {
+          "name" : "hippostd:content",
+          "type" : "STRING",
+          "multiple" : false,
+          "values" : [ "${(nationalindicator.caveats)!}" ]
+        } ],
+        "nodes" : [ ]
+      }, {
+        "name" : "nationalindicatorlibrary:dataSource",
+        "primaryType" : "hippostd:html",
+        "mixinTypes" : [ ],
+        "properties" : [ {
+          "name" : "hippostd:content",
+          "type" : "STRING",
+          "multiple" : false,
+          "values" : [ "${(nationalindicator.dataSource)!}" ]
+        } ],
+        "nodes" : [ ]
+      }, {
+        "name" : "nationalindicatorlibrary:denominator",
+        "primaryType" : "hippostd:html",
+        "mixinTypes" : [ ],
+        "properties" : [ {
+          "name" : "hippostd:content",
+          "type" : "STRING",
+          "multiple" : false,
+          "values" : [ "${(nationalindicator.denominator)!}" ]
+        } ],
+        "nodes" : [ ]
+      }, {
+        "name" : "nationalindicatorlibrary:interpretationGuidelines",
+        "primaryType" : "hippostd:html",
+        "mixinTypes" : [ ],
+        "properties" : [ {
+          "name" : "hippostd:content",
+          "type" : "STRING",
+          "multiple" : false,
+          "values" : [ "" ]
+        } ],
+        "nodes" : [ ]
+      }, {
+        "name" : "nationalindicatorlibrary:numerator",
+        "primaryType" : "hippostd:html",
+        "mixinTypes" : [ ],
+        "properties" : [ {
+          "name" : "hippostd:content",
+          "type" : "STRING",
+          "multiple" : false,
+          "values" : [ "${(nationalindicator.numerator)!}" ]
+        } ],
+        "nodes" : [ ]
+      } ]
+    }, {
+      "name" : "nationalindicatorlibrary:purpose",
+      "primaryType" : "hippostd:html",
+      "mixinTypes" : [ ],
+      "properties" : [ {
+        "name" : "hippostd:content",
+        "type" : "STRING",
+        "multiple" : false,
+        "values" : [ "${(nationalindicator.purpose)!}" ]
+      } ],
+      "nodes" : [ ]
+    } ]
   }, {
     "name" : "nationalindicatorlibrary:topbar",
     "primaryType" : "nationalindicatorlibrary:topbar",
     "mixinTypes" : [ ],
-    "properties" : [  {
+    "properties" : [ {
+      "name" : "nationalindicatorlibrary:reportingPeriod",
+      "type" : "STRING",
+      "multiple" : false,
+      "values" : [ "${(nationalindicator.reportingPeriod)!}" ]
+    }, {
+      "name" : "nationalindicatorlibrary:reviewDate",
+      "type" : "DATE",
+      "multiple" : false,
+      "values" : [ "${(nationalindicator.reviewDate)!}" ]
+    }, {
+      "name" : "nationalindicatorlibrary:basedOn",
+      "type" : "STRING",
+      "multiple" : false,
+      "values" : [ "${(nationalindicator.basedOn)!}" ]
+    } ],
+    "nodes" : [ {
       "name" : "nationalindicatorlibrary:contactAuthor",
       "primaryType" : "nationalindicatorlibrary:contactAuthor",
       "mixinTypes" : [ ],
       "properties" : [ {
+        "name" : "nationalindicatorlibrary:contactAuthorEmail",
+        "type" : "STRING",
+        "multiple" : false,
+        "values" : [ "${(nationalindicator.contactAuthorEmail)!}" ]
+      }, {
         "name" : "nationalindicatorlibrary:contactAuthorName",
         "type" : "STRING",
         "multiple" : false,
         "values" : [ "${(nationalindicator.contactAuthorName)!}" ]
       } ],
       "nodes" : [ ]
-    }, {
-    "name" : "nationalindicatorlibrary:title",
-    "type" : "STRING",
-    "multiple" : false,
-<<<<<<< HEAD
-    "values" : [ "${nationalindicator.localizedName}" ]
-  },<#if nationalindicator.taxonomyKeys?has_content> {
-       "name" : "hippotaxonomy:keys",
-       "type" : "STRING",
-       "multiple" : true,
-       "values" : [ "${nationalindicator.taxonomyKeys}" ]
-  }</#if> ],
-  "nodes" : [ ]
+    } ]
+  } ]
 }
-=======
-    "values" : [ "${nationalindicator.title}" ]
-    },{
-      "name" : "nationalindicatorlibrary:publishedBy",
-      "type" : "STRING",
-      "multiple" : false,
-      "values" : [ "${(nationalindicator.publishedBy)!}" ]
-    }, {
-      "name" : "nationalindicatorlibrary:reportingPeriod",
-      "type" : "STRING",
-      "multiple" : false,
-      "values" : [ "${(nationalindicator.reportingPeriod)!}" ]
-    }, {
-      "name" : "nationalindicatorlibrary:reportingLevel",
-      "type" : "STRING",
-      "multiple" : false,
-      "values" : [ "${(nationalindicator.reportingLevel)!}" ]
-    }, {
-      "name" : "nationalindicatorlibrary:basedOn",
-      "type" : "STRING",
-      "multiple" : false,
-      "values" : [ "${(nationalindicator.basedOn)!}" ]
-    }, {
-      "name" : "nationalindicatorlibrary:assuranceDate",
-      "type" : "STRING",
-      "multiple" : false,
-      "values" : [ "${(nationalindicator.assuranceDate)!}" ]    
-    }, {
-      "name" : "nationalindicatorlibrary:reviewDate",
-      "type" : "STRING",
-      "multiple" : false,
-      "values" : [ "${(nationalindicator.reviewDate)!}" ]
-    },{
-      "name" : "nationalindicatorlibrary:assuredStatus",
-      "type" : "STRING",
-      "multiple" : false,
-      "values" : [ "true" ]
-    }]
-  }],
-    "nodes" : [ ]
-  }  
->>>>>>> [RPS-308] CI migration: better import mechanism


### PR DESCRIPTION
This comprises of the final raft of changes made to support the migration/import of NIL content. Mainly consists of:

1) Attachment handling (via file path to PDF packs)
2) Doc type restructuring and additional fields
3) Content sanitisation and html/richtext handling

As discussed offline, there appear to be two commits here due to a git merge/rebase/squash issue but as far as I can tell the changes will merge fine into master.